### PR TITLE
[BE] 지출 내역 조회시 이모지 가져오는 기능을 구현한다.

### DIFF
--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/controller/ExpenseController.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/controller/ExpenseController.java
@@ -1,8 +1,8 @@
 package com.jjangiji.hankkimoa.expense.controller;
 
 import com.jjangiji.hankkimoa.expense.service.ExpenseService;
-import com.jjangiji.hankkimoa.expense.service.dto.response.DailyExpenseResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.request.ExpenseCreateRequest;
+import com.jjangiji.hankkimoa.expense.service.dto.response.DailyExpenseResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.response.MonthlyExpenseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +27,7 @@ public class ExpenseController {
         return ResponseEntity.created(URI.create("/expenses/" + expenseId)).build();
     }
 
-    @GetMapping("/api/users/{userId}/expenses")
+    @GetMapping("/api/users/{userId}/expenses/range")
     public ResponseEntity<MonthlyExpenseResponse> readMonthlyExpenses(@PathVariable("userId") Long userId,
                                                                       @RequestParam("from") LocalDate from,
                                                                       @RequestParam("to") LocalDate to) {
@@ -35,12 +35,11 @@ public class ExpenseController {
         return ResponseEntity.ok(monthlyExpenseResponse);
     }
 
-    @GetMapping("/api/users/{userId}/saving-goals/{savingGoalId}/expenses")
+    @GetMapping("/api/users/{userId}/expenses")
     public ResponseEntity<DailyExpenseResponse> readDailyExpenses(
             @PathVariable("userId") Long userId,
-            @PathVariable Long savingGoalId,
-            @RequestParam LocalDate date) {
-        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(userId, savingGoalId, date);
+            @RequestParam("date") LocalDate date) {
+        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(userId, date);
         return ResponseEntity.ok(dailyExpenseResponse);
     }
 

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/controller/ExpenseSavingGoalController.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/controller/ExpenseSavingGoalController.java
@@ -1,11 +1,12 @@
 package com.jjangiji.hankkimoa.expense.controller;
 
+import com.jjangiji.hankkimoa.auth.config.AuthRequiredPrincipal;
 import com.jjangiji.hankkimoa.expense.service.ExpenseSavingGoalService;
 import com.jjangiji.hankkimoa.expense.service.dto.request.ExpenseSavingGoalCreateRequest;
 import com.jjangiji.hankkimoa.expense.service.dto.response.ExpenseSavingGoalCreateResponse;
+import com.jjangiji.hankkimoa.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,11 +17,11 @@ public class ExpenseSavingGoalController {
 
     private final ExpenseSavingGoalService expenseSavingGoalService;
 
-    @PostMapping("/api/users/{userId}/saving-goals")
+    @PostMapping("/api/saving-goals")
     public ResponseEntity<ExpenseSavingGoalCreateResponse> createExpense(
-            @PathVariable("userId") Long userId,
+            @AuthRequiredPrincipal User user,
             @RequestBody ExpenseSavingGoalCreateRequest request) {
-        ExpenseSavingGoalCreateResponse response = expenseSavingGoalService.createExpenseSavingGoal(userId, request);
+        ExpenseSavingGoalCreateResponse response = expenseSavingGoalService.createExpenseSavingGoal(user, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/domain/DailyExpenses.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/domain/DailyExpenses.java
@@ -1,6 +1,8 @@
 package com.jjangiji.hankkimoa.expense.domain;
 
 import lombok.Getter;
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,5 +28,19 @@ public class DailyExpenses {
         return (int) dailyExpenses.stream()
                 .filter(dailyExpense -> dailyExpense.getExpenseStatus().equals(ExpenseStatus.BAD))
                 .count();
+    }
+
+    public List<Expense> getExpensesDescending(LocalDate expenseDate) {
+        return dailyExpenses.stream()
+                .filter(dailyExpense -> dailyExpense.getExpenseDate().equals(expenseDate))
+                .flatMap(dailyExpense -> dailyExpense.getExpenses().stream())
+                .sorted(Comparator.comparing(Expense::getCreatedAt).reversed())
+                .toList();
+    }
+
+    public List<Expense> getExpenses() {
+        return dailyExpenses.stream()
+                .flatMap(dailyExpense -> dailyExpense.getExpenses().stream())
+                .toList();
     }
 }

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/domain/Expense.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/domain/Expense.java
@@ -55,9 +55,10 @@ public class Expense extends BaseEntity {
     @NotNull(message = "평점이 NULL일 수 없습니다.")
     private Integer rating;
 
-    public Expense(ExpenseSavingGoal expenseSavingGoal, Restaurant restaurant, String restaurantName,
-                   String menuName,
-                   Integer expense, String memo, LocalDate expenseDate, Integer rating) {
+    public Expense(ExpenseSavingGoal expenseSavingGoal, Restaurant restaurant,
+                   String restaurantName, String menuName,
+                   Integer expense, String memo,
+                   LocalDate expenseDate, Integer rating) {
         validateMemo(memo);
         validateExpense(expense);
         validateExpenseDate(expenseDate);
@@ -70,6 +71,14 @@ public class Expense extends BaseEntity {
         this.memo = memo;
         this.expenseDate = expenseDate;
         this.rating = rating;
+    }
+
+    public Expense(Long id, ExpenseSavingGoal expenseSavingGoal,
+                   Restaurant restaurant, String restaurantName,
+                   String menuName, Integer expense,
+                   String memo, LocalDate expenseDate, Integer rating) {
+        this(expenseSavingGoal, restaurant, restaurantName, menuName, expense, memo, expenseDate, rating);
+        this.id = id;
     }
 
     private void validateMemo(String memo) {

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseEmojiRepository.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseEmojiRepository.java
@@ -2,10 +2,22 @@ package com.jjangiji.hankkimoa.expense.repository;
 
 import com.jjangiji.hankkimoa.expense.domain.Expense;
 import com.jjangiji.hankkimoa.expense.domain.ExpenseEmoji;
+import com.jjangiji.hankkimoa.expense.service.dto.response.EmojiResponse;
 import com.jjangiji.hankkimoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface ExpenseEmojiRepository extends JpaRepository<ExpenseEmoji, Long> {
 
     boolean existsExpenseEmojiByExpenseAndUserAndEmojiId(Expense expense, User user, Integer emojiId);
+
+    @Query(value = """
+        SELECT emoji_id AS emojiId, CAST(COUNT(*) AS INT) AS count
+        FROM expense_emoji
+        WHERE expense_id = :expenseId
+        GROUP BY emoji_id
+    """, nativeQuery = true)
+    List<EmojiResponse> countExpenseEmojisByExpenseId(@Param("expenseId") Long expenseId);
 }

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseRepository.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseRepository.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
-    List<Expense> findAllByExpenseDateOrderByCreatedAtDesc(LocalDate date);
     List<Expense> findAllByExpenseSavingGoalOrderByExpenseDateAsc(ExpenseSavingGoal expenseSavingGoal);
     List<Expense> findAllByExpenseDateBetweenOrderByExpenseDateAsc(LocalDate startDate, LocalDate endDate);
 }

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseSavingGoalRepository.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/repository/ExpenseSavingGoalRepository.java
@@ -4,6 +4,7 @@ import com.jjangiji.hankkimoa.expense.domain.ExpenseSavingGoal;
 import com.jjangiji.hankkimoa.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ExpenseSavingGoalRepository extends JpaRepository<ExpenseSavingGoal, Long> {
@@ -11,4 +12,8 @@ public interface ExpenseSavingGoalRepository extends JpaRepository<ExpenseSaving
     @Query("SELECT e FROM ExpenseSavingGoal e "
             + "WHERE e.user = :user ORDER BY e.createdAt DESC limit 1 ")
     Optional<ExpenseSavingGoal> findLastByUser(User user);
+
+    @Query("SELECT e FROM ExpenseSavingGoal e " +
+            "WHERE :date BETWEEN e.startDate AND e.endDate")
+    Optional<ExpenseSavingGoal> findByDate(LocalDate date);
 }

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseSavingGoalService.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseSavingGoalService.java
@@ -21,18 +21,12 @@ public class ExpenseSavingGoalService {
     private final UserRepository userRepository;
 
     @Transactional
-    public ExpenseSavingGoalCreateResponse createExpenseSavingGoal(Long userId, ExpenseSavingGoalCreateRequest request) {
-        User user = readUser(userId);
+    public ExpenseSavingGoalCreateResponse createExpenseSavingGoal(User user, ExpenseSavingGoalCreateRequest request) {
         ExpenseSavingGoal expenseSavingGoal = new ExpenseSavingGoal(user, request.budget(), request.startDate(), request.endDate());
         validateExpenseSavingGoalExist(user, expenseSavingGoal);
 
         ExpenseSavingGoal savedExpenseSavingGoal = expenseSavingGoalRepository.save(expenseSavingGoal);
         return new ExpenseSavingGoalCreateResponse(savedExpenseSavingGoal.getId());
-    }
-
-    private User readUser(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new HankkiMoaException(ExceptionCode.USER_NOT_FOUND));
     }
 
     private void validateExpenseSavingGoalExist(User user, ExpenseSavingGoal expenseSavingGoal) {

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
@@ -2,14 +2,16 @@ package com.jjangiji.hankkimoa.expense.service;
 
 import com.jjangiji.hankkimoa.common.exception.ExceptionCode;
 import com.jjangiji.hankkimoa.common.exception.HankkiMoaException;
+import com.jjangiji.hankkimoa.expense.domain.DailyExpenses;
 import com.jjangiji.hankkimoa.expense.domain.Expense;
 import com.jjangiji.hankkimoa.expense.domain.ExpenseSavingGoal;
-import com.jjangiji.hankkimoa.expense.domain.DailyExpenses;
 import com.jjangiji.hankkimoa.expense.domain.SavingGoalStatus;
+import com.jjangiji.hankkimoa.expense.repository.ExpenseEmojiRepository;
 import com.jjangiji.hankkimoa.expense.repository.ExpenseRepository;
 import com.jjangiji.hankkimoa.expense.repository.ExpenseSavingGoalRepository;
-import com.jjangiji.hankkimoa.expense.service.dto.response.DailyExpenseResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.request.ExpenseCreateRequest;
+import com.jjangiji.hankkimoa.expense.service.dto.response.DailyExpenseResponse;
+import com.jjangiji.hankkimoa.expense.service.dto.response.EmojiResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.response.ExpenseResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.response.MonthlyExpenseResponse;
 import com.jjangiji.hankkimoa.expense.service.dto.response.SavingGoalStatusResponse;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class ExpenseService {
     private final RestaurantRepository restaurantRepository;
     private final ExpenseSavingGoalRepository expenseSavingGoalRepository;
     private final ExpenseRepository expenseRepository;
+    private final ExpenseEmojiRepository expenseEmojiRepository;
 
     @Transactional
     public Long createExpense(ExpenseCreateRequest request) {
@@ -61,10 +65,11 @@ public class ExpenseService {
 
         List<Expense> expenses = expenseRepository.findAllByExpenseSavingGoalOrderByExpenseDateAsc(expenseSavingGoal);
         DailyExpenses dailyExpenses = new DailyExpenses(expenses);
-        List<Expense> dailyExpense = expenseRepository.findAllByExpenseDateOrderByCreatedAtDesc(date);
 
         List<SimpleExpenseResponse> simpleExpenseResponses = toSimpleExpenseResponses(dailyExpenses);
         SavingGoalStatusResponse savingGoalStatusResponse = toSavingGoalStatusResponse(expenseSavingGoal, expenses);
+
+        List<Expense> dailyExpense = expenseRepository.findAllByExpenseDateOrderByCreatedAtDesc(date);
         List<ExpenseResponse> expenseResponses = toExpenseResponses(dailyExpense);
         return new DailyExpenseResponse(simpleExpenseResponses, savingGoalStatusResponse, expenseResponses);
     }
@@ -93,11 +98,16 @@ public class ExpenseService {
     }
 
     private List<ExpenseResponse> toExpenseResponses(List<Expense> dateExpenses) {
-        return dateExpenses.stream()
-                .map(expense -> new ExpenseResponse(
-                        expense.getRestaurantName(), expense.getMenuName(),
-                        expense.getExpense(), expense.getMemo()))
-                .toList();
+        List<ExpenseResponse> responses = new ArrayList<>();
+
+        for (Expense expense : dateExpenses) {
+            List<EmojiResponse> expenseEmojis = expenseEmojiRepository.countExpenseEmojisByExpenseId(expense.getId());
+
+            responses.add(new ExpenseResponse(expense.getRestaurantName(), expense.getMenuName(),
+                    expense.getExpense(), expense.getMemo(), expenseEmojis));
+        }
+
+        return responses;
     }
 
     @Transactional(readOnly = true)

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
@@ -60,9 +60,9 @@ public class ExpenseService {
     }
 
     @Transactional(readOnly = true)
-    public DailyExpenseResponse readDailyExpenses(Long userId, Long savingGoalId, LocalDate date) {
+    public DailyExpenseResponse readDailyExpenses(Long userId, LocalDate date) {
         // todo 접근 가능 여부 확인
-        ExpenseSavingGoal expenseSavingGoal = readExpenseSavingGoal(savingGoalId);
+        ExpenseSavingGoal expenseSavingGoal = readExpenseSavingGoal(date);
         List<Expense> savingGoalExpenses = expenseRepository.findAllByExpenseSavingGoalOrderByExpenseDateAsc(expenseSavingGoal);
         DailyExpenses dailyExpenses = new DailyExpenses(savingGoalExpenses);
 
@@ -72,6 +72,12 @@ public class ExpenseService {
         List<Expense> todayExpenses = dailyExpenses.getExpensesDescending(date);
         List<ExpenseResponse> expenseResponses = toExpenseResponses(todayExpenses);
         return new DailyExpenseResponse(simpleExpenseResponses, savingGoalStatusResponse, expenseResponses);
+    }
+
+    private ExpenseSavingGoal readExpenseSavingGoal(LocalDate date) {
+        return expenseSavingGoalRepository.findByDate(date)
+                .orElseThrow(() -> new HankkiMoaException(
+                        ExceptionCode.EXPENSE_SAVING_GOAL_NOT_FOUND));
     }
 
     private List<SimpleExpenseResponse> toSimpleExpenseResponses(DailyExpenses expenseByDates) {

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/ExpenseService.java
@@ -61,21 +61,17 @@ public class ExpenseService {
 
     @Transactional(readOnly = true)
     public DailyExpenseResponse readDailyExpenses(Long userId, Long savingGoalId, LocalDate date) {
+        // todo 접근 가능 여부 확인
         ExpenseSavingGoal expenseSavingGoal = readExpenseSavingGoal(savingGoalId);
-
-        List<Expense> expenses = expenseRepository.findAllByExpenseSavingGoalOrderByExpenseDateAsc(expenseSavingGoal);
-        DailyExpenses dailyExpenses = new DailyExpenses(expenses);
+        List<Expense> savingGoalExpenses = expenseRepository.findAllByExpenseSavingGoalOrderByExpenseDateAsc(expenseSavingGoal);
+        DailyExpenses dailyExpenses = new DailyExpenses(savingGoalExpenses);
 
         List<SimpleExpenseResponse> simpleExpenseResponses = toSimpleExpenseResponses(dailyExpenses);
-        SavingGoalStatusResponse savingGoalStatusResponse = toSavingGoalStatusResponse(expenseSavingGoal, expenses);
+        SavingGoalStatusResponse savingGoalStatusResponse = toSavingGoalStatusResponse(expenseSavingGoal, dailyExpenses);
 
-        List<Expense> dailyExpense = expenseRepository.findAllByExpenseDateOrderByCreatedAtDesc(date);
-        List<ExpenseResponse> expenseResponses = toExpenseResponses(dailyExpense);
+        List<Expense> todayExpenses = dailyExpenses.getExpensesDescending(date);
+        List<ExpenseResponse> expenseResponses = toExpenseResponses(todayExpenses);
         return new DailyExpenseResponse(simpleExpenseResponses, savingGoalStatusResponse, expenseResponses);
-    }
-
-    private void validateExpenseIsPublic() {
-        // TODO 접근 가능 여부 확인
     }
 
     private List<SimpleExpenseResponse> toSimpleExpenseResponses(DailyExpenses expenseByDates) {
@@ -87,11 +83,13 @@ public class ExpenseService {
                 .toList();
     }
 
-    private SavingGoalStatusResponse toSavingGoalStatusResponse(ExpenseSavingGoal expenseSavingGoal, List<Expense> dailyExpenses) {
-        int usedPercentage = expenseSavingGoal.calculatePercentage(dailyExpenses);
+    private SavingGoalStatusResponse toSavingGoalStatusResponse(ExpenseSavingGoal expenseSavingGoal, DailyExpenses dailyExpenses) {
+        List<Expense> expenses = dailyExpenses.getExpenses();
+
+        int usedPercentage = expenseSavingGoal.calculatePercentage(expenses);
         return new SavingGoalStatusResponse(
                 expenseSavingGoal.getBudget(),
-                expenseSavingGoal.calculateRemainingBudget(dailyExpenses),
+                expenseSavingGoal.calculateRemainingBudget(expenses),
                 usedPercentage,
                 SavingGoalStatus.convert(usedPercentage).getMessage()
         );
@@ -103,7 +101,8 @@ public class ExpenseService {
         for (Expense expense : dateExpenses) {
             List<EmojiResponse> expenseEmojis = expenseEmojiRepository.countExpenseEmojisByExpenseId(expense.getId());
 
-            responses.add(new ExpenseResponse(expense.getRestaurantName(), expense.getMenuName(),
+            responses.add(new ExpenseResponse(
+                    expense.getRestaurantName(), expense.getMenuName(),
                     expense.getExpense(), expense.getMemo(), expenseEmojis));
         }
 

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/dto/response/EmojiResponse.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/dto/response/EmojiResponse.java
@@ -1,0 +1,4 @@
+package com.jjangiji.hankkimoa.expense.service.dto.response;
+
+public record EmojiResponse(Integer emojiId, Integer count) {
+}

--- a/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/dto/response/ExpenseResponse.java
+++ b/backend/hankkimoa/src/main/java/com/jjangiji/hankkimoa/expense/service/dto/response/ExpenseResponse.java
@@ -1,5 +1,7 @@
 package com.jjangiji.hankkimoa.expense.service.dto.response;
 
+import java.util.List;
+
 public record ExpenseResponse(String restaurant, String menu,
-                              Integer expense, String memo) {
+                              Integer expense, String memo, List<EmojiResponse> emojis) {
 }

--- a/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/domain/DailyExpensesTest.java
+++ b/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/domain/DailyExpensesTest.java
@@ -1,7 +1,7 @@
 package com.jjangiji.hankkimoa.expense.domain;
 
-import com.jjangiji.hankkimoa.restaurant.domain.CategoryDictionary;
 import com.jjangiji.hankkimoa.restaurant.domain.Category;
+import com.jjangiji.hankkimoa.restaurant.domain.CategoryDictionary;
 import com.jjangiji.hankkimoa.restaurant.domain.Restaurant;
 import com.jjangiji.hankkimoa.user.domain.LoginType;
 import com.jjangiji.hankkimoa.user.domain.Role;

--- a/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/repository/ExpenseEmojiRepositoryTest.java
+++ b/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/repository/ExpenseEmojiRepositoryTest.java
@@ -4,8 +4,9 @@ import com.jjangiji.hankkimoa.config.RepositoryTest;
 import com.jjangiji.hankkimoa.expense.domain.Expense;
 import com.jjangiji.hankkimoa.expense.domain.ExpenseEmoji;
 import com.jjangiji.hankkimoa.expense.domain.ExpenseSavingGoal;
-import com.jjangiji.hankkimoa.restaurant.domain.CategoryDictionary;
+import com.jjangiji.hankkimoa.expense.service.dto.response.EmojiResponse;
 import com.jjangiji.hankkimoa.restaurant.domain.Category;
+import com.jjangiji.hankkimoa.restaurant.domain.CategoryDictionary;
 import com.jjangiji.hankkimoa.restaurant.domain.Restaurant;
 import com.jjangiji.hankkimoa.restaurant.repository.CategoryRepository;
 import com.jjangiji.hankkimoa.restaurant.repository.RestaurantRepository;
@@ -19,13 +20,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 class ExpenseEmojiRepositoryTest extends RepositoryTest {
 
-    private User user;
-    private ExpenseSavingGoal expenseSavingGoal;
+    private User user1;
+    private User user2;
+    private ExpenseSavingGoal expenseSavingGoal1;
+    private ExpenseSavingGoal expenseSavingGoal2;
     private Restaurant restaurant;
-    private Expense expense;
+    private Expense expense1;
+    private Expense expense2;
     private final LocalDate now = LocalDate.now();
 
     @Autowired
@@ -43,12 +50,18 @@ class ExpenseEmojiRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(new User("hankkimoa@gmail.com", "한끼", "hankkiImage", LoginType.KAKAO, Role.USER));
-        expenseSavingGoal = expenseSavingGoalRepository.save(new ExpenseSavingGoal(user, 80_000,
+        user1 = userRepository.save(new User("hankkimoa@gmail.com", "한끼", "hankkiImage", LoginType.KAKAO, Role.USER));
+        user2 = userRepository.save(new User("hankkimoa22@gmail.com", "한끼22", "hankkiImage", LoginType.KAKAO, Role.USER));
+        expenseSavingGoal1 = expenseSavingGoalRepository.save(new ExpenseSavingGoal(user1, 80_000,
+                LocalDate.now(), LocalDate.now().plusDays(6)));
+        expenseSavingGoal2 = expenseSavingGoalRepository.save(new ExpenseSavingGoal(user2, 180_000,
                 LocalDate.now(), LocalDate.now().plusDays(6)));
         Category category = categoryRepository.save(new Category(CategoryDictionary.한식));
         restaurant  = restaurantRepository.save(new Restaurant(category, "한끼식당", "12345", 10000));
-        expense = expenseRepository.save(new Expense(expenseSavingGoal, restaurant,
+        expense1 = expenseRepository.save(new Expense(expenseSavingGoal1, restaurant,
+                "한끼식당", "순두부", 8_000,
+                "든든하게 먹음!", now, 5));
+        expense2 = expenseRepository.save(new Expense(expenseSavingGoal2, restaurant,
                 "한끼식당", "순두부", 8_000,
                 "든든하게 먹음!", now, 5));
     }
@@ -57,10 +70,10 @@ class ExpenseEmojiRepositoryTest extends RepositoryTest {
     @Test
     void emojiExist() {
         // given
-        expenseEmojiRepository.save(new ExpenseEmoji(user, expense, 1));
+        expenseEmojiRepository.save(new ExpenseEmoji(user1, expense1, 1));
 
         // when
-        boolean result = expenseEmojiRepository.existsExpenseEmojiByExpenseAndUserAndEmojiId(expense, user, 1);
+        boolean result = expenseEmojiRepository.existsExpenseEmojiByExpenseAndUserAndEmojiId(expense1, user1, 1);
 
         // then
         Assertions.assertThat(result).isTrue();
@@ -70,9 +83,36 @@ class ExpenseEmojiRepositoryTest extends RepositoryTest {
     @Test
     void emojiNotExist() {
         // given & when
-        boolean result = expenseEmojiRepository.existsExpenseEmojiByExpenseAndUserAndEmojiId(expense, user, 1);
+        boolean result = expenseEmojiRepository.existsExpenseEmojiByExpenseAndUserAndEmojiId(expense1, user1, 1);
 
         // then
         Assertions.assertThat(result).isFalse();
+    }
+
+    @DisplayName("지출 내역에 대한 이모지 반환 성공")
+    @Test
+    void countExpenseEmojisByExpenseId() {
+        // given
+        int emojiId1 = 1;
+        int emojiId2 = 2;
+        expenseEmojiRepository.save(new ExpenseEmoji(user1, expense1, emojiId1));
+        expenseEmojiRepository.save(new ExpenseEmoji(user2, expense1, emojiId1));
+        expenseEmojiRepository.save(new ExpenseEmoji(user1, expense1, emojiId2));
+
+        expenseEmojiRepository.save(new ExpenseEmoji(user1, expense2, emojiId1));
+
+        // when
+        List<EmojiResponse> emojiResponses = expenseEmojiRepository.countExpenseEmojisByExpenseId(expense1.getId());
+
+        // then
+        Map<Integer, Integer> emojiCountMap = emojiResponses.stream()
+                .collect(Collectors.toMap(
+                        EmojiResponse::emojiId,
+                        EmojiResponse::count
+                ));
+
+        Assertions.assertThat(emojiCountMap.get(emojiId1)).isEqualTo(2);
+        Assertions.assertThat(emojiCountMap.get(emojiId2)).isEqualTo(1);
+        Assertions.assertThat(emojiResponses).hasSize(2);
     }
 }

--- a/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/repository/ExpenseRepositoryTest.java
+++ b/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/repository/ExpenseRepositoryTest.java
@@ -49,46 +49,6 @@ class ExpenseRepositoryTest extends RepositoryTest {
         restaurant  = restaurantRepository.save(new Restaurant(category, "한끼식당", "12345", 10000));
     }
 
-    @DisplayName("오늘 지출 목록 조회 성공")
-    @Test
-    void findAllByExpenseDate() {
-        // given
-        Expense expense1 = new Expense(expenseSavingGoal, restaurant,
-                "한끼식당", "순두부", 8_000,
-                "든든하게 먹음!", now, 5);
-        Expense expense2 = new Expense(expenseSavingGoal, restaurant,
-                "한끼식당", "순두부", 8_000,
-                "든든하게 먹음!", before, 5);
-        expenseRepository.saveAll(List.of(expense1, expense2));
-
-        // when
-        List<Expense> expenses = expenseRepository.findAllByExpenseDateOrderByCreatedAtDesc(now);
-
-        // then
-        Assertions.assertThat(expenses).containsOnly(expense1);
-    }
-
-    @DisplayName("오늘 지출 목록 조회 성공 : 최신순 정렬")
-    @Test
-    void findAllByExpenseDateOrderByCreatedAtDesc() {
-        // given
-        Expense expense1 = new Expense(expenseSavingGoal, restaurant,
-                "한끼식당", "순두부", 8_000,
-                "든든하게 먹음!", now, 5);
-        expenseRepository.save(expense1);
-        Expense expense2 = new Expense(expenseSavingGoal, restaurant,
-                "한끼식당", "순두부", 8_000,
-                "든든하게 먹음!", now, 5);
-        expenseRepository.save(expense2);
-
-        // when
-        List<Expense> expenses = expenseRepository.findAllByExpenseDateOrderByCreatedAtDesc(now);
-
-        // then
-        Assertions.assertThat(expenses.get(0).getCreatedAt())
-                .isAfter(expenses.get(1).getCreatedAt());
-    }
-
     @DisplayName("지출 절약 목표 금액 내의 지출 전부 조회")
     @Test
     void findAllByExpenseSavingGoalOrder() {

--- a/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/service/ExpenseSavingGoalTest.java
+++ b/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/service/ExpenseSavingGoalTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDate;
 
-
 class ExpenseSavingGoalTest extends IntegrationTest {
 
     @Autowired
@@ -39,7 +38,7 @@ class ExpenseSavingGoalTest extends IntegrationTest {
         ExpenseSavingGoalCreateRequest request = new ExpenseSavingGoalCreateRequest(100_000, now, sevenDayAfter);
 
         // when & then
-        Assertions.assertThatCode(() -> expenseSavingGoalService.createExpenseSavingGoal(user.getId(), request))
+        Assertions.assertThatCode(() -> expenseSavingGoalService.createExpenseSavingGoal(user, request))
                 .doesNotThrowAnyException();;
     }
 
@@ -48,10 +47,10 @@ class ExpenseSavingGoalTest extends IntegrationTest {
     void failWhenExpenseSavingGoalAlreadyExist() {
         // given
         ExpenseSavingGoalCreateRequest request = new ExpenseSavingGoalCreateRequest(100_000, now, sevenDayAfter);
-        expenseSavingGoalService.createExpenseSavingGoal(user.getId(), request);
+        expenseSavingGoalService.createExpenseSavingGoal(user, request);
 
         // when & then
-        Assertions.assertThatCode(() -> expenseSavingGoalService.createExpenseSavingGoal(user.getId(), request))
+        Assertions.assertThatCode(() -> expenseSavingGoalService.createExpenseSavingGoal(user, request))
                 .isInstanceOf(HankkiMoaException.class)
                 .hasMessage(ExceptionCode.EXPENSE_SAVING_GOAL_ALREADY_EXIST.getMessage());
     }

--- a/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/service/ExpenseServiceTest.java
+++ b/backend/hankkimoa/src/test/java/com/jjangiji/hankkimoa/expense/service/ExpenseServiceTest.java
@@ -95,7 +95,7 @@ class ExpenseServiceTest extends IntegrationTest {
         expenseRepository.saveAll(List.of(expense1, expense2));
 
         // when
-        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(1L, expenseSavingGoal.getId(), now);
+        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(1L, now);
 
         // then
         Assertions.assertThat(dailyExpenseResponse.dailyExpensesStatus()).hasSize(2);
@@ -107,7 +107,7 @@ class ExpenseServiceTest extends IntegrationTest {
     @Test
     void readDailyExpenses_withNoExpenses() {
         // given & when
-        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(1L, expenseSavingGoal.getId(), now);
+        DailyExpenseResponse dailyExpenseResponse = expenseService.readDailyExpenses(1L, now);
 
         // then
         Assertions.assertThat(dailyExpenseResponse.dailyExpensesStatus()).isEmpty();


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
Closes #36 

## 📝 작업 내용
- [x] 지출 내역 조회시 이모지 정보 함께 반환
- [x] 불필요한 쿼리문 삭제
- [x] 지출 내역 조회 API URI 스펙 변경
  - [x] /api/users/{userId}/expenses?date=2025-04-06 -> savingGoal 부분 삭제 

## ✨ 논의하고 싶은 내용

## 💬 리뷰 요구사항

## 🎈 변경 사항 체크리스트
- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 문서를 작성하거나 수정했나요? (필요한 경우)
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
